### PR TITLE
pass pointer to content to free function

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -39,7 +39,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <new>
-#include "stdint.hpp"
 #include "likely.hpp"
 #include "metadata.hpp"
 #include "err.hpp"
@@ -93,11 +92,11 @@ void zmq::msg_t::init_size (size_t size_)
 
 namespace {
 
-void do_nothing(void *, void *) {}
+void do_nothing(zmq::content_t *, void *) {}
 
 }
 
-void zmq::msg_t::init_data (void *data_, size_t size_, msg_free_fn *ffn_,
+void zmq::msg_t::init_data (void *data_, size_t size_, msg_free_fn ffn_,
     void *hint_)
 {
     if (ffn_ == nullptr) {
@@ -118,8 +117,8 @@ void zmq::msg_t::init_data (void *data_, size_t size_, msg_free_fn *ffn_,
     new(&content_->refcnt) zmq::atomic_counter_t();
 }
 
-void zmq::msg_t::init_content(zmq_content *data_, size_t size_,
-	msg_free_fn *ffn_, void *hint_)
+void zmq::msg_t::init_content(content_t *data_, size_t size_,
+	msg_free_fn ffn_, void *hint_)
 {
 	init_lsm(size_);
 	content_ = reinterpret_cast<content_t *>(data_);
@@ -134,7 +133,7 @@ void zmq::msg_t::init_content(zmq_content *data_, size_t size_,
 	new (&content_->refcnt) zmq::atomic_counter_t ();
 }
 
-void zmq::msg_t::init_iov(iovec *iov, int iovcnt, size_t size, msg_free_fn *ffn_, void *hint_)
+void zmq::msg_t::init_iov(iovec *iov, int iovcnt, size_t size, msg_free_fn ffn_, void *hint_)
 {
 	zmq_assert(iov != NULL && iovcnt > 0 && ffn_ != NULL);
 	init_lsm(size);
@@ -149,8 +148,8 @@ void zmq::msg_t::init_iov(iovec *iov, int iovcnt, size_t size, msg_free_fn *ffn_
 	new (&content_->refcnt) zmq::atomic_counter_t ();
 }
 
-void zmq::msg_t::init_iov_content(zmq_content *content, iovec *iov, int iovcnt, size_t size,
-	msg_free_fn *ffn_, void *hint_)
+void zmq::msg_t::init_iov_content(content_t *content, iovec *iov, int iovcnt, size_t size,
+	msg_free_fn ffn_, void *hint_)
 {
 	init_lsm(size);
 	content_ = (content_t*)content;
@@ -185,7 +184,7 @@ void zmq::msg_t::close()
     //  count has dropped to zero, deallocate it.
     if (!(flags & msg_t::shared) || !content->refcnt.sub(1)) {
         if (content->ffn)
-            content->ffn(content->data_iov->iov_base, content->hint);
+            content->ffn(content, content->hint);
 
         switch (flags & (malloced | pool_alloc)) {
         case pool_alloc:

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -570,14 +570,14 @@ void zmq_msg_init_size (zmq_msg_t *msg_, size_t size_)
 void zmq_msg_init_data (zmq_msg_t *msg_, void *data_, size_t size_,
     zmq_free_fn *ffn_, void *hint_)
 {
-    ((zmq::msg_t*) msg_)->init_data (data_, size_, ffn_, hint_);
+    ((zmq::msg_t*) msg_)->init_data (data_, size_, (zmq::msg_free_fn)ffn_, hint_);
 }
 
 void
 zmq_msg_init_content(zmq_msg_t *msg_, zmq_content *content_, size_t size_,
 	zmq_free_fn *ffn_, void *hint_)
 {
-    ((zmq::msg_t*) msg_)->init_content (content_, size_, ffn_, hint_);
+    ((zmq::msg_t*) msg_)->init_content ((zmq::content_t *)content_, size_, (zmq::msg_free_fn)ffn_, hint_);
 }
 
 void zmq_msg_init_iov (zmq_msg_t *msg, struct iovec *iov,
@@ -592,14 +592,15 @@ void zmq_msg_init_iov (zmq_msg_t *msg, struct iovec *iov,
 void zmq_msg_init_iov_size (zmq_msg_t *msg_, struct iovec *iov,
                       int iovcnt, size_t size, zmq_free_fn *ffn, void *hint)
 {
-    ((zmq::msg_t*) msg_)->init_iov(iov, iovcnt, size, ffn, hint);
+    ((zmq::msg_t*) msg_)->init_iov(iov, iovcnt, size, (zmq::msg_free_fn)ffn, hint);
 }
 
 void zmq_msg_init_iov_size_content (zmq_msg_t *msg,
         struct zmq_content *content, struct iovec *iov,
         int iovcnt, size_t size, zmq_free_fn *ffn, void *hint)
 {
-    ((zmq::msg_t*) msg)->init_iov_content(content, iov, iovcnt, size, ffn, hint);
+    ((zmq::msg_t*) msg)->init_iov_content((zmq::content_t*)content, iov, iovcnt, size,
+					  (zmq::msg_free_fn)ffn, hint);
 }
 
 int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)


### PR DESCRIPTION
Since content can have an iovec, passing just a pointer to the first buffer to free function is not enough sometimes. Pass the whole content structure instead.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

